### PR TITLE
вложения к договору во второй таблице

### DIFF
--- a/src/docManager/controller/MainController.java
+++ b/src/docManager/controller/MainController.java
@@ -3,12 +3,14 @@ package docManager.controller;
 //import docManager.model.DataAdditionally;
 
 import docManager.util.ArrayUtil;
+import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.*;
 
 import docManager.Main;
+import docManager.model.Attachment;
 import docManager.model.MainData;
 import docManager.util.DateUtil;
 import javafx.scene.control.cell.PropertyValueFactory;
@@ -26,11 +28,11 @@ public class MainController {
     @FXML
     private TableColumn<MainData, LocalDate> timeContractColumn;
     @FXML
-    private TableView<MainData> linkTable;
+    private TableView<Attachment> linkTable;
     @FXML
-    private TableColumn<MainData, ObservableList<String>> contractColumn;
+    private TableColumn<Attachment, String> contractColumn;
     @FXML
-    private TableColumn<MainData, ObservableList<String>> linkColumn;
+    private TableColumn<Attachment, String> linkColumn;
 
     @FXML
     private Label numberContractLabel;
@@ -70,8 +72,9 @@ public class MainController {
         dateExecutionContractColumn.setCellValueFactory(cellData -> cellData.getValue().dateExecutionContractProperty());
         timeContractColumn.setCellValueFactory(cellData -> cellData.getValue().timeContractProperty());
 
-        contractColumn.setCellValueFactory(cellData -> cellData.getValue().getNameLink());
-
+        contractColumn.setCellValueFactory(cellData -> new SimpleStringProperty(cellData.getValue().getContract().getNumberContract()));
+        linkColumn.setCellValueFactory(new PropertyValueFactory<>("link"));
+        
         // Очистка дополнительной информации об адресате.
         showContractDetails(null);
 
@@ -125,7 +128,14 @@ public class MainController {
 
         // Добавление в таблицу данных из наблюдаемого списка
         contractTable.setItems(main.getContractData());
-        linkTable.setItems(main.getContractData());
+        
+        
+        contractTable.getSelectionModel().selectedItemProperty().addListener( (ov,o,n) -> {
+        	if(n!= null){
+        		linkTable.setItems(n.getNameLink());
+        	}
+        });
+        
     }
 
     /**

--- a/src/docManager/model/Attachment.java
+++ b/src/docManager/model/Attachment.java
@@ -1,0 +1,40 @@
+package docManager.model;
+
+public class Attachment {
+
+	private MainData contract;
+
+	private String link;
+
+	public Attachment() {
+
+	}
+
+	public Attachment(MainData contract, String link) {
+		super();
+		this.contract = contract;
+		this.link = link;
+	}
+
+	public MainData getContract() {
+		return contract;
+	}
+
+	public void setContract(MainData contract) {
+		this.contract = contract;
+	}
+
+	public String getLink() {
+		return link;
+	}
+
+	public void setLink(String link) {
+		this.link = link;
+	}
+
+	@Override
+	public String toString() {
+		return "Attachment [link=" + link + "]";
+	}
+
+}

--- a/src/docManager/model/MainData.java
+++ b/src/docManager/model/MainData.java
@@ -11,178 +11,175 @@ import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
-
 import javafx.beans.binding.ListExpression;
 
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 public class MainData {
-    private final StringProperty numberContract;
-    private final ObjectProperty<LocalDate> dateContract;
-    private final StringProperty counterparty;
-    private final StringProperty subjectContract;
-    private final ObjectProperty<LocalDate> dateExecutionContract;
-    private final ObjectProperty<LocalDate> timeContract;
-    private final IntegerProperty price;
-    private final IntegerProperty priceOnly;
-    private final ListProperty<String> nameLink;
+	private final StringProperty numberContract;
+	private final ObjectProperty<LocalDate> dateContract;
+	private final StringProperty counterparty;
+	private final StringProperty subjectContract;
+	private final ObjectProperty<LocalDate> dateExecutionContract;
+	private final ObjectProperty<LocalDate> timeContract;
+	private final IntegerProperty price;
+	private final IntegerProperty priceOnly;
+	private final ListProperty<Attachment> nameLink;
 
-    private int[] sumСosts = new int[12];
+	private int[] sumСosts = new int[12];
 
-    /**
-     * Конструктор по умолчанию.
-     */
-    public MainData() {
-        this(null, null, null);
-    }
+	/**
+	 * Конструктор по умолчанию.
+	 */
+	public MainData() {
+		this(null, null, null);
+	}
 
-    /**
-     * Конструктор с некоторыми начальными данными.
-     */
-    public MainData(String numberContract, LocalDate dateExecutionContract, LocalDate timeContract) {
-        this.numberContract = new SimpleStringProperty(numberContract);
-        this.dateExecutionContract = new SimpleObjectProperty(dateExecutionContract);
-        this.timeContract = new SimpleObjectProperty(timeContract);
+	/**
+	 * Конструктор с некоторыми начальными данными.
+	 */
+	public MainData(String numberContract, LocalDate dateExecutionContract, LocalDate timeContract) {
+		this.numberContract = new SimpleStringProperty(numberContract);
+		this.dateExecutionContract = new SimpleObjectProperty(dateExecutionContract);
+		this.timeContract = new SimpleObjectProperty(timeContract);
 
-        // Какие-то фиктивные начальные данные для удобства тестирования.
-        this.dateContract = new SimpleObjectProperty();
-        this.counterparty = new SimpleStringProperty();
-        this.subjectContract = new SimpleStringProperty();
-        this.price = new SimpleIntegerProperty();
-        this.priceOnly = new SimpleIntegerProperty();
-        this.nameLink  = new SimpleListProperty<>(FXCollections.observableArrayList());
-        this.nameLink.add("qwerty");
-        this.nameLink.add("asdfgh");
-    }
+		// Какие-то фиктивные начальные данные для удобства тестирования.
+		this.dateContract = new SimpleObjectProperty();
+		this.counterparty = new SimpleStringProperty();
+		this.subjectContract = new SimpleStringProperty();
+		this.price = new SimpleIntegerProperty();
+		this.priceOnly = new SimpleIntegerProperty();
+		this.nameLink = new SimpleListProperty<>(FXCollections.observableArrayList());
+		this.nameLink.add(new Attachment(this, "qwerty"));
+		this.nameLink.add(new Attachment(this, "asdfgh"));
+	}
 
-    public ListProperty<String> getNameLink() {
-        return nameLink;
-    }
+	public ListProperty<Attachment> getNameLink() {
+		return nameLink;
+	}
 
-    public ListProperty<String> setNameLink(String nameLink) {
-        this.nameLink.add("qwe");
-        return getNameLink();
-    }
+	public ListProperty<Attachment> setNameLink(String nameLink) {
+		this.nameLink.add(new Attachment(this, nameLink));
+		return getNameLink();
+	}
 
+	public Integer getSumСostsInt() {
+		Integer temp = 0;
+		for (int i = 0; i < sumСosts.length; i++) {
+			temp = temp + sumСosts[i];
+		}
+		return temp;
+	}
 
-    public Integer getSumСostsInt() {
-        Integer temp = 0;
-        for (int i = 0; i < sumСosts.length; i++) {
-            temp = temp + sumСosts[i];
-        }
-        return temp;
-    }
+	public int[] getCosts() {
+		return sumСosts;
+	}
 
-    public int[] getCosts() {
-        return sumСosts;
-    }
+	public void setSumСosts(int costs) {
+		for (int i = 0; i < sumСosts.length; i++) {
+			if (sumСosts[i] == 0) {
+				sumСosts[i] = costs;
+				return;
+			}
+		}
+	}
 
-    public void setSumСosts(int costs) {
-        for (int i = 0; i < sumСosts.length; i++) {
-            if (sumСosts[i] == 0) {
-                sumСosts[i] = costs;
-                return;
-            }
-        }
-    }
+	public int getPriceOnly() {
+		return priceOnly.get();
+	}
 
-    public int getPriceOnly() {
-        return priceOnly.get();
-    }
+	public IntegerProperty priceOnlyProperty() {
+		return priceOnly;
+	}
 
-    public IntegerProperty priceOnlyProperty() {
-        return priceOnly;
-    }
+	public void setPriceOnly(int priceOnly) {
+		this.priceOnly.set(priceOnly);
+	}
 
-    public void setPriceOnly(int priceOnly) {
-        this.priceOnly.set(priceOnly);
-    }
+	public String getNumberContract() {
+		return numberContract.get();
+	}
 
-    public String getNumberContract() {
-        return numberContract.get();
-    }
+	public StringProperty numberContractProperty() {
+		return numberContract;
+	}
 
-    public StringProperty numberContractProperty() {
-        return numberContract;
-    }
+	public void setNumberContract(String numberContract) {
+		this.numberContract.set(numberContract);
+	}
 
-    public void setNumberContract(String numberContract) {
-        this.numberContract.set(numberContract);
-    }
+	@XmlJavaTypeAdapter(LocalDateAdapter.class)
+	public LocalDate getDateContract() {
+		return dateContract.get();
+	}
 
-    @XmlJavaTypeAdapter(LocalDateAdapter.class)
-    public LocalDate getDateContract() {
-        return dateContract.get();
-    }
+	public ObjectProperty<LocalDate> dateContractProperty() {
+		return dateContract;
+	}
 
-    public ObjectProperty<LocalDate> dateContractProperty() {
-        return dateContract;
-    }
+	public void setDateContract(LocalDate dateContract) {
+		this.dateContract.set(dateContract);
+	}
 
-    public void setDateContract(LocalDate dateContract) {
-        this.dateContract.set(dateContract);
-    }
+	public String getCounterparty() {
+		return counterparty.get();
+	}
 
-    public String getCounterparty() {
-        return counterparty.get();
-    }
+	public StringProperty counterpartyProperty() {
+		return counterparty;
+	}
 
-    public StringProperty counterpartyProperty() {
-        return counterparty;
-    }
+	public void setCounterparty(String counterparty) {
+		this.counterparty.set(counterparty);
+	}
 
-    public void setCounterparty(String counterparty) {
-        this.counterparty.set(counterparty);
-    }
+	public String getSubjectContract() {
+		return subjectContract.get();
+	}
 
-    public String getSubjectContract() {
-        return subjectContract.get();
-    }
+	public StringProperty subjectContractProperty() {
+		return subjectContract;
+	}
 
-    public StringProperty subjectContractProperty() {
-        return subjectContract;
-    }
+	public void setSubjectContract(String subjectContract) {
+		this.subjectContract.set(subjectContract);
+	}
 
-    public void setSubjectContract(String subjectContract) {
-        this.subjectContract.set(subjectContract);
-    }
+	@XmlJavaTypeAdapter(LocalDateAdapter.class)
+	public LocalDate getDateExecutionContract() {
+		return dateExecutionContract.get();
+	}
 
-    @XmlJavaTypeAdapter(LocalDateAdapter.class)
-    public LocalDate getDateExecutionContract() {
-        return dateExecutionContract.get();
-    }
+	public ObjectProperty<LocalDate> dateExecutionContractProperty() {
+		return dateExecutionContract;
+	}
 
-    public ObjectProperty<LocalDate> dateExecutionContractProperty() {
-        return dateExecutionContract;
-    }
+	public void setDateExecutionContract(LocalDate dateExecutionContract) {
+		this.dateExecutionContract.set(dateExecutionContract);
+	}
 
-    public void setDateExecutionContract(LocalDate dateExecutionContract) {
-        this.dateExecutionContract.set(dateExecutionContract);
-    }
+	@XmlJavaTypeAdapter(LocalDateAdapter.class)
+	public LocalDate getTimeContract() {
+		return timeContract.get();
+	}
 
-    @XmlJavaTypeAdapter(LocalDateAdapter.class)
-    public LocalDate getTimeContract() {
-        return timeContract.get();
-    }
+	public ObjectProperty<LocalDate> timeContractProperty() {
+		return timeContract;
+	}
 
-    public ObjectProperty<LocalDate> timeContractProperty() {
-        return timeContract;
-    }
+	public void setTimeContract(LocalDate timeContract) {
+		this.timeContract.set(timeContract);
+	}
 
-    public void setTimeContract(LocalDate timeContract) {
-        this.timeContract.set(timeContract);
-    }
+	public int getPrice() {
+		return price.get();
+	}
 
-    public int getPrice() {
-        return price.get();
-    }
+	public IntegerProperty priceProperty() {
+		return price;
+	}
 
-    public IntegerProperty priceProperty() {
-        return price;
-    }
-
-    public void setPrice(int price) {
-        this.price.set(price);
-    }
+	public void setPrice(int price) {
+		this.price.set(price);
+	}
 }
-

--- a/src/docManager/view/fxml/menuBarOverview.fxml
+++ b/src/docManager/view/fxml/menuBarOverview.fxml
@@ -12,7 +12,7 @@
                 <Menu mnemonicParsing="false" text="Файл">
                     <items>
                         <MenuItem mnemonicParsing="false"    text="Создать" />
-                  <MenuItem mnemonicParsing="false"      text="Открыть...">
+                  <MenuItem mnemonicParsing="false"      text="Открыть..." onAction="#handleOpen">
                      <accelerator>
                         <KeyCodeCombination alt="UP" code="O" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
                      </accelerator></MenuItem>


### PR DESCRIPTION
Зафейлил переводы строк, видимо, поясню что сделано.
Добавил класс Attachment для хранения ссылки на вложенный документ, соответственно вторая таблица описывается как `private TableView<Attachment> linkTable;` и заполняется при выделение договора в первой таблице.
В Attachment есть ссылка на MainData, который "владеет" Attachment, в принципе только для того, чтобы во второй таблице отобразить номер договора через такую дикую конструкцию:
`contractColumn.setCellValueFactory(cellData -> new SimpleStringProperty(cellData.getValue().getContract().getNumberContract()));`
В итоге как-то так:
![2019-06-07 13_55_50-SpringTime - Док xml](https://user-images.githubusercontent.com/8995401/59099574-2131f800-892c-11e9-9046-6e53ddaca8fc.png)
